### PR TITLE
複数のstop_waypointに対応

### DIFF
--- a/fulanghua_srvs/CMakeLists.txt
+++ b/fulanghua_srvs/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_service_files(
     FILES
     Pose.srv
+    suspend_nav.srv
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/fulanghua_srvs/srv/suspend_nav.srv
+++ b/fulanghua_srvs/srv/suspend_nav.srv
@@ -1,0 +1,3 @@
+int64 resume_input
+---
+int64 resume_input

--- a/fulanghua_waypoints_nav/CMakeLists.txt
+++ b/fulanghua_waypoints_nav/CMakeLists.txt
@@ -33,7 +33,7 @@ include_directories(
 
 add_executable(waypoints_saver src/waypoints_saver.cpp)
 add_executable(waypoints_nav src/waypoints_nav.cpp)
-
+add_executable(suspend_nav src/suspend_nav.cpp)
 add_dependencies(waypoints_nav ${fulanghua_srvs_EXPORTED_TARGETS})
 
 target_link_libraries(waypoints_saver
@@ -45,3 +45,7 @@ target_link_libraries(waypoints_nav
     ${yaml-cpp_LIBRARIES}
 )
 
+target_link_libraries(suspend_nav
+    ${catkin_LIBRARIES}
+#    ${yaml-cpp_LIBRARIES}
+)

--- a/fulanghua_waypoints_nav/src/suspend_nav.cpp
+++ b/fulanghua_waypoints_nav/src/suspend_nav.cpp
@@ -1,0 +1,25 @@
+#include <ros/ros.h>
+#include <fulanghua_srvs/suspend_nav.h>
+
+#include <vector>
+#include <fstream>
+#include <string>
+#include <exception>
+#include <math.h>
+#include <limits>
+
+bool add(fulanghua_srvs::suspend_nav::Request &req, fulanghua_srvs::suspend_nav::Response &res){
+    res.resume_input = req.resume_input;
+    /*ROS_INFO("request resume_input: %ld", (long int)req.resume_input);
+    ROS_INFO("response resume_input: %ld", (long int)res.resume_input);*/
+    return true;
+}
+int main(int argc, char **argv){
+    ros::init(argc,argv,"suspend_nav");
+    ros::NodeHandle nh;
+    ros::ServiceServer service = nh.advertiseService("suspend_nav",add);
+    ROS_INFO("stopping now.");
+    ros::spin();
+
+    return 0;
+}

--- a/fulanghua_waypoints_nav/src/waypoints_saver.cpp
+++ b/fulanghua_waypoints_nav/src/waypoints_saver.cpp
@@ -141,5 +141,5 @@ int main(int argc, char *argv[]){
     WaypointsSaver saver;
     saver.run();
 
-    return 0;
+return 0;
 }


### PR DESCRIPTION
つくばチャレンジ2018にて複数の白線停止位置があったため、以下のように対応。
・複数のstop_waypointをfulanghua_waypoints_nav/src/waypoints_nav.cppで指定
　→fulanghua_waypoints_nav/src/suspend_nav.cppのサービスが送られてくるまで停止